### PR TITLE
fix: accept non-finite reals, cap summary unique set, CLI robustness & dead-code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to vcd_analyzer. Detailed per-release
 notes live on the [GitHub Releases](https://github.com/neveltyc/VCD_ANALYZER/releases) page.
 
+## [Unreleased]
+
+### Fixed
+
+- **Non-finite real values are no longer silently dropped.** C99 `%g` renders
+  non-finite doubles as `inf`/`-inf`/`nan`, and IEEE 1364's real_number is
+  `%g` output — but the parser's real regex rejected them, so the whole
+  value_change record vanished from `dump`, `info`'s time range, and
+  `summary` counts with no diagnostic. They are now kept in the stream
+  verbatim (locked by `verify/test_real_nonfinite.py`). Equality targets
+  still reject `inf`/`nan`: nan never compares equal and inf has no finite
+  target, so no condition can match one — a stated limitation, not data loss.
+- **`summary`'s distinct-value (`unique`) set grew without bound** — a 32-bit
+  counter over tens of millions of changes kept every value string alive.
+  The set now caps at `VCD_ANALYZER_MAX_UNIQUE_VALUES` (default 65536, read
+  per call like `VCD_ANALYZER_TOKEN_CHUNK_SIZE`); beyond the cap the count is
+  a lower bound and the row says so: JSON `unique_is_exact: false` (key
+  appears only when capped), text `uniq=N+`. No existing key changed name,
+  type, or meaning.
+
+### Internal
+
+- Removed dead code: `fmt_time`'s unreachable trailing return, `_limit`'s
+  unused `cmd` parameter, and `cmd_dump`'s duplicate `last_t`/`cur` sentinels
+  (one memoized sentinel now drives both the `T=` header and the formatted
+  time).
+- CLI: Ctrl-C exits 130 instead of printing a traceback; stdout/stderr are
+  forced to UTF-8 (`errors='replace'`) so a legacy Windows codepage cannot
+  turn a valid dump into `UnicodeEncodeError`.
+
 ## [1.5.0](https://github.com/neveltyc/VCD_ANALYZER/releases/tag/v1.5.0) - 2026-08-24
 
 `search`'s condition system, rebuilt around the shape the downstream [RWaveAnalyzer](https://github.com/neveltyc/RWaveAnalyzer) port converged on: the edge trigger moves out of a flag and into the condition grammar, and OR becomes a repeatable flag. Along the way three silent-wrong-answer bugs found while comparing the two implementations are fixed — a real signal's value read as a bit string, a mis-typed in-string boolean accepted as an opaque literal, and a repeated `--condition` quietly discarding all but the last. Every non-`search` command is byte-identical to 1.4.0 at equal `--limit` (verified with `verify/bench.py --baseline`); the full suite passes, now 162 tests including three new files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to vcd_analyzer. Detailed per-release
 notes live on the [GitHub Releases](https://github.com/neveltyc/VCD_ANALYZER/releases) page.
 
-## [Unreleased]
+## [1.5.1](https://github.com/neveltyc/VCD_ANALYZER/releases/tag/v1.5.1) - 2026-09-08
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.5.0-3366cc?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.5.1-3366cc?style=flat-square">
   <img alt="Python" src="https://img.shields.io/badge/python-3.9+-3366cc?style=flat-square&logo=python&logoColor=white">
   <img alt="License" src="https://img.shields.io/badge/license-MIT-3366cc?style=flat-square">
-  <img alt="Tests" src="https://img.shields.io/badge/tests-94%20passed-22aa55?style=flat-square">
+  <img alt="Tests" src="https://img.shields.io/badge/tests-169%20passed-22aa55?style=flat-square">
 </p>
 
 ---
@@ -67,7 +67,7 @@ Single file, no dependencies, Python 3.9+.
 curl -fsSL https://raw.githubusercontent.com/neveltyc/VCD_ANALYZER/main/vcd_analyzer.py -o vcd_analyzer.py
 
 # Pinned release tag (recommended — avoids compatibility surprises from main)
-curl -fsSL https://raw.githubusercontent.com/neveltyc/VCD_ANALYZER/v1.5.0/vcd_analyzer.py -o vcd_analyzer.py
+curl -fsSL https://raw.githubusercontent.com/neveltyc/VCD_ANALYZER/v1.5.1/vcd_analyzer.py -o vcd_analyzer.py
 
 # Verify
 python vcd_analyzer.py --version
@@ -180,6 +180,7 @@ Full per-version notes live on the [GitHub Releases](https://github.com/neveltyc
 
 | Version | Highlight |
 |:--------|:----------|
+| `1.5.1` | Parser keeps non-finite real values (`inf`/`-inf`/`nan` — previously the whole record was silently dropped); `summary` caps its per-signal unique-value set (`VCD_ANALYZER_MAX_UNIQUE_VALUES`, default 65536, lower bound flagged as `unique_is_exact: false`); Ctrl-C exits 130 instead of a traceback; stdout/stderr forced to UTF-8 |
 | `1.5.0` | `changed(SIG)` edge predicate replaces the `--changed` flag; repeatable `--condition` ORs clauses; condition matching follows the signal's declared type (fixes real-signal false positives/negatives); unusable condition targets are rejected instead of silently unmatched; `--limit` default 500 with a clearer truncation notice |
 | `1.4.0` | Internal refactor: separate the event stream from derived state into three distinct parser views (`iter_events` raw / `iter_transitions` / `state_at` snapshots); no change to any command's output, value-change hot path slightly faster |
 | `1.3.20` | Preserve intra-timestamp value changes; rebuild `info`'s time range on one forward scanner (parser-parity, ~1.5× faster, survives huge/`$dumpall` tails); `search --changed` counts each change; `info` `--limit` validation and empty-data output |

--- a/README_zh.md
+++ b/README_zh.md
@@ -7,10 +7,10 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/版本-1.5.0-3366cc?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/版本-1.5.1-3366cc?style=flat-square">
   <img alt="Python" src="https://img.shields.io/badge/python-3.9+-3366cc?style=flat-square&logo=python&logoColor=white">
   <img alt="License" src="https://img.shields.io/badge/license-MIT-3366cc?style=flat-square">
-  <img alt="Tests" src="https://img.shields.io/badge/测试-94%20passed-22aa55?style=flat-square">
+  <img alt="Tests" src="https://img.shields.io/badge/测试-169%20passed-22aa55?style=flat-square">
 </p>
 
 ---
@@ -65,7 +65,7 @@ python vcd_analyzer.py summary sim.vcd --filter dll_*
 curl -fsSL https://raw.githubusercontent.com/neveltyc/VCD_ANALYZER/main/vcd_analyzer.py -o vcd_analyzer.py
 
 # 锁定已发布版本（推荐，避免 main 分支更新破坏兼容性）
-curl -fsSL https://raw.githubusercontent.com/neveltyc/VCD_ANALYZER/v1.5.0/vcd_analyzer.py -o vcd_analyzer.py
+curl -fsSL https://raw.githubusercontent.com/neveltyc/VCD_ANALYZER/v1.5.1/vcd_analyzer.py -o vcd_analyzer.py
 
 # 验证
 python vcd_analyzer.py --version
@@ -168,6 +168,7 @@ python -m unittest discover -s verify -p "test_cli.py"
 
 | 版本 | 亮点 |
 |:------|:-----|
+| `1.5.1` | 解析器保留非有限实数值(`inf`/`-inf`/`nan`,此前整条记录被静默丢弃);`summary` 的单信号 unique 集合加上限(`VCD_ANALYZER_MAX_UNIQUE_VALUES`,默认 65536,超限时以 `unique_is_exact: false` 标注下界);Ctrl-C 以 130 干净退出而非打印堆栈;stdout/stderr 强制 UTF-8 |
 | `1.5.0` | `changed(SIG)` 边沿谓词取代 `--changed` 标志;`--condition` 可重复以 OR 子句;条件匹配依据信号声明类型(修复 real 信号的假阳/假阴);无法成立的条件目标改为报错而非静默无匹配;`--limit` 默认值改为 500,截断提示更清晰 |
 | `1.4.0` | 内部重构:将事件流与派生状态分层为解析器的三个不同视图(`iter_events` 原始 / `iter_transitions` / `state_at` 快照);所有命令输出不变,值变化热路径略快 |
 | `1.3.20` | 保留同一时间戳内的多次值变化;`info` 时间范围改用单一前向扫描器(与解析器等价,约快 1.5×,能扛超大/`$dumpall` 尾部);`search --changed` 逐次计数;`info` 的 `--limit` 校验与空数据输出 |

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -283,7 +283,7 @@ Every time value appears in three forms:
 - 1-bit: `0`, `1`, `x`, `z`
 - Multi-bit clean: `decimal (0xhex)` — e.g., `255 (0xff)`
 - Multi-bit with unknowns: `b01xz` prefix notation
-- Real/realtime: float string as-is from simulator
+- Real/realtime: float string as-is from simulator, including non-finite `inf`/`nan`
 - Event type: `triggered`
 
 ### Filter vs condition signal matching

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -14,8 +14,8 @@ All commands support `--json` for structured output. **Always use `--json` when 
 ## Setup (one-time)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/neveltyc/VCD_ANALYZER/v1.5.0/vcd_analyzer.py -o vcd_analyzer.py
-python3 vcd_analyzer.py --version   # expect: vcd_analyzer 1.5.0
+curl -fsSL https://raw.githubusercontent.com/neveltyc/VCD_ANALYZER/v1.5.1/vcd_analyzer.py -o vcd_analyzer.py
+python3 vcd_analyzer.py --version   # expect: vcd_analyzer 1.5.1
 ```
 
 No pip install, no virtualenv, no dependencies. Python 3.9+.

--- a/vcd_analyzer.py
+++ b/vcd_analyzer.py
@@ -87,7 +87,7 @@ Notes:
   since coincidence is a property of the tick rather than of any one record.
 """
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'
 
 import sys
 import os

--- a/vcd_analyzer.py
+++ b/vcd_analyzer.py
@@ -166,6 +166,17 @@ _REAL_RE = re.compile(
 )
 _REAL_MAX_LEN = 64  # Defensive cap: %.16g + sign + exponent fits well under this
 
+# C99 printf("%g") also renders non-finite doubles as 'inf' / '-inf' / 'nan'
+# (float() additionally accepts 'infinity'), and IEEE 1364's real_number is
+# %g output — so these are legal value_change texts the numeric pattern above
+# cannot match. This companion pattern keeps such records in the stream
+# instead of silently dropping a legal dump record (the pre-fix behavior lost
+# the event from dump, info's time range, and summary counts with no
+# diagnostic). Equality targets still reject them in _parse_target_value:
+# nan never compares equal and inf has no finite target, so no condition can
+# match one — a stated limitation, not data loss.
+_REAL_NONFINITE_RE = re.compile(r'^[+-]?(?:inf(?:inity)?|nan)$', re.IGNORECASE)
+
 # Fast 4-state validation tables. str.translate() runs entirely in C, so
 # "delete every allowed character, then check for an empty remainder" is the
 # fastest stdlib test for "are all characters drawn from this set?". This
@@ -382,11 +393,11 @@ def fmt_time(ts, ts_sec):
     if ts_sec <= 0:
         return '?'
     sec = ts * ts_sec
+    # u == 's' always matches the bound below, so the loop always returns.
     for u in ('fs', 'ps', 'ns', 'us', 'ms', 's'):
         scaled = sec / _UNITS[u]
         if -1000.0 < scaled < 1000.0 or u == 's':
             return f'{scaled:g}{u}'
-    return f'{sec:g}s'
 
 
 # -- Value formatting --------------------------------------------------------
@@ -1183,13 +1194,15 @@ class VCDParser:
             body = tok[1:]
             # Consume the identifier_code before validating (see the b-token
             # note above): 'rnan x!' must not leak 'x!' back to be mis-read as a
-            # scalar change. NaN/Inf are legal %g output that _REAL_RE rejects.
+            # scalar change. Non-finite %g output (inf/nan) is a legal
+            # real_number and is kept; see _REAL_NONFINITE_RE.
             sym = next_token()
             if self._is_structural_token(sym):
                 if sym is not None:
                     pushback.append(sym)
                 return None
-            if len(body) > _REAL_MAX_LEN or not _REAL_RE.match(body):
+            if len(body) > _REAL_MAX_LEN or not (
+                    _REAL_RE.match(body) or _REAL_NONFINITE_RE.match(body)):
                 return None
             return sym, body
 
@@ -1742,7 +1755,7 @@ def _json(obj):
     print(json.dumps(obj, ensure_ascii=False, separators=(',', ':')))
 
 
-def _limit(args, cmd):
+def _limit(args):
     """Resolve global output limit. --verbose disables truncation unless an
     explicit --limit was supplied. --limit 0 always means unlimited."""
     val = getattr(args, 'limit', None)
@@ -2469,9 +2482,19 @@ def _summary_rows(vcd, t0, t1, sids):
     For 1-bit signals, rise/fall counts are reported for clean 0->1 and 1->0
     transitions only. x/z-related transitions still count as changes, but not
     as rises/falls.
+
+    The distinct-value count (`unique`) is exact up to
+    VCD_ANALYZER_MAX_UNIQUE_VALUES (default 65536, read per call like
+    VCD_ANALYZER_TOKEN_CHUNK_SIZE); beyond the cap it is a lower bound, and
+    the row says so: JSON `unique_is_exact: false` (the key appears only when
+    capped), text `uniq=N+`. This bounds memory on e.g. a 32-bit counter over
+    tens of millions of changes instead of keeping every value string alive.
     """
     selected = _selected_sids(vcd, sids)
     init_boundary = 0 if t0 == 0 else t0 - 1
+    # Per-call env read so tests can shrink the cap via monkeypatch.setenv
+    # without reloading the module.
+    unique_cap = _env_int('VCD_ANALYZER_MAX_UNIQUE_VALUES', 65536)
 
     # Baseline: {sid: val} — cheap str overwrites, same as state_at.
     # Stats dicts are created only once per signal, not on every baseline event.
@@ -2484,6 +2507,7 @@ def _summary_rows(vcd, t0, t1, sids):
             'changes': 0, 'first_at': None, 'last_at': None,
             'initial': init_val, 'last': init_val,
             'unique': {init_val} if init_val is not None else set(),
+            'unique_capped': False,
             'rise_count': 0 if is_scalar else None,
             'fall_count': 0 if is_scalar else None,
             'scalar': is_scalar,
@@ -2520,7 +2544,12 @@ def _summary_rows(vcd, t0, t1, sids):
                 s['first_at'] = t
             s['last_at'] = t
             s['last'] = val
-            s['unique'].add(val)
+            if val not in s['unique']:
+                if len(s['unique']) < unique_cap:
+                    s['unique'].add(val)
+                else:
+                    # At cap: the count stays a lower bound, flagged on the row.
+                    s['unique_capped'] = True
 
     # Signals that were in baseline but had no in-window events (static).
     for sid, val in baseline.items():
@@ -2550,6 +2579,8 @@ def _summary_rows(vcd, t0, t1, sids):
             row['last_at_h'] = row['last_at']
         if s['unique']:
             row['unique'] = len(s['unique'])
+            if s['unique_capped']:
+                row['unique_is_exact'] = False
         row['_width'] = info['width']
         row['_type'] = info.get('type', 'wire')
         rows.append(row)
@@ -2573,7 +2604,7 @@ def _public_row(row, verbose=False):
 
 
 def cmd_info(vcd, args):
-    _limit(args, 'info')
+    _limit(args)
     t_min, t_max = vcd.scan_time_range()
     ts = vcd.ts_sec
     synth = [s for s in vcd.signals.values() if s.get('synthesized')]
@@ -2642,7 +2673,7 @@ def cmd_info(vcd, args):
 
 
 def cmd_list(vcd, args):
-    limit = _limit(args, 'list')
+    limit = _limit(args)
     sids = vcd.match(args.filter)
     entries = []
     for sid, info in vcd.signals.items():
@@ -2683,7 +2714,7 @@ def cmd_dump(vcd, args):
     if t1 is not None and t1 < t0:
         raise _TimeParseError('end time must be >= begin time')
     sids = vcd.match(args.filter)
-    limit = _limit(args, 'dump')
+    limit = _limit(args)
     verbose = getattr(args, 'verbose', False)
     # Many value_changes share one timestamp, so memoize the formatted time
     # across consecutive events. fmt_time() depends only on (t, ts), so this
@@ -2730,8 +2761,9 @@ def cmd_dump(vcd, args):
     shown = 0
     total = 0
     truncated = False
+    # One memoized sentinel drives both the T= header and the formatted time:
+    # last_t and cur always changed on the same events.
     cur = object()
-    last_t = object()
     last_th = None
     for t, sid, val in vcd.iter_events(t0, t1, sids):
         total += 1
@@ -2739,11 +2771,9 @@ def cmd_dump(vcd, args):
             truncated = True
             break
         info = vcd.signals[sid]
-        if t != last_t:
-            last_t = t
-            last_th = fmt_time(t, ts)
         if t != cur:
             cur = t
+            last_th = fmt_time(t, ts)
             buf_append('T={}\n'.format(last_th))
         if verbose:
             buf_append('  {:<55} w={} {} = {}\n'.format(
@@ -2783,7 +2813,7 @@ def cmd_summary(vcd, args):
                             'fall_count': 0 if info['width'] == 1 else None,
                             'init': '(undef)', 'last': '(undef)',
                             '_width': info['width'], '_type': info.get('type', 'wire')})
-    limit = _limit(args, 'summary')
+    limit = _limit(args)
     shown, trunc = _clip(ordered, limit)
     begin_h = fmt_time(t0, ts)
     end_h = fmt_time(t1, ts) if t1 is not None else None
@@ -2808,9 +2838,12 @@ def cmd_summary(vcd, args):
             if getattr(args, 'verbose', False):
                 edge = '' if r.get('rise_count') is None else ' r={} f={}'.format(
                     r.get('rise_count', 0), r.get('fall_count', 0))
+                uniq = str(r.get('unique', 0))
+                if not r.get('unique_is_exact', True):
+                    uniq += '+'
                 print('  {:<45} w={} {} chg={}{} init={} last={} first@{} last@{} uniq={}'.format(
                     r['path'], r['_width'], r['_type'], r['changes'], edge, r['init'], r['last'],
-                    r.get('first_at', '-'), r.get('last_at', '-'), r.get('unique', 0)))
+                    r.get('first_at', '-'), r.get('last_at', '-'), uniq))
             else:
                 edge = '' if r.get('rise_count') is None else ' r={} f={}'.format(
                     r.get('rise_count', 0), r.get('fall_count', 0))
@@ -2849,7 +2882,7 @@ def cmd_snapshot(vcd, args):
             info = vcd.signals[sid]
             rows.append({'path': info['path'], 'value': None, 'undefined': True,
                          'width': info['width'], 'type': info.get('type', 'wire')})
-    limit = _limit(args, 'snapshot')
+    limit = _limit(args)
     shown, trunc = _clip(rows, limit)
     if args.json:
         _json({'at': fmt_time(t_at, ts), 'at_ticks': t_at, 'at_h': fmt_time(t_at, ts),
@@ -2898,7 +2931,7 @@ def cmd_compare(vcd, args):
                 d['width'] = info['width']
                 d['type'] = info.get('type', 'wire')
             diffs.append(d)
-    limit = _limit(args, 'compare')
+    limit = _limit(args)
     shown, trunc = _clip(diffs, limit)
     if args.json:
         _json({'t1': fmt_time(ta, ts), 't1_ticks': ta, 't1_h': fmt_time(ta, ts),
@@ -2958,7 +2991,7 @@ def cmd_search(vcd, args):
     selected = set(c['sid'] for cl in clauses for c in cl)
     selected.update(show_sids)
 
-    limit = _limit(args, 'search')
+    limit = _limit(args)
     verbose = getattr(args, 'verbose', False)
     cond_label = _join_clauses(clauses, _condition_label)
     cond_text = _join_clauses(clauses, _condition_result_text)
@@ -3333,8 +3366,20 @@ if __name__ == '__main__':
     import signal as _sig
     if hasattr(_sig, 'SIGPIPE'):
         _sig.signal(_sig.SIGPIPE, _sig.SIG_DFL)
+    # Verbatim VCD text and ensure_ascii=False JSON can carry non-ASCII
+    # characters (signal paths, $version/$date strings). Force UTF-8 so a
+    # legacy Windows codepage cannot turn a valid dump into a
+    # UnicodeEncodeError. No-op where reconfigure() is unavailable.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding='utf-8', errors='replace')
+        except (AttributeError, ValueError, OSError):
+            pass
     try:
         main()
+    except KeyboardInterrupt:
+        # Conventional 128 + SIGINT(2): a clean exit, no traceback.
+        sys.exit(130)
     except BrokenPipeError:
         try:
             os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())

--- a/verify/test_cli.py
+++ b/verify/test_cli.py
@@ -13,7 +13,7 @@ FIX_HANDSHAKE = ROOT / "verify" / "fixtures" / "handshake_trace.vcd"
 FIX_BUS_RANGE = ROOT / "verify" / "fixtures" / "bus_range_trace.vcd"
 FIX_ESCAPED = ROOT / "verify" / "fixtures" / "escaped_trace.vcd"
 
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 LEGACY_SEARCH = False
 SUPPORTS_EDGES = False
 SUPPORTS_HANDSHAKE = False

--- a/verify/test_real_nonfinite.py
+++ b/verify/test_real_nonfinite.py
@@ -1,0 +1,71 @@
+"""Non-finite real values (C99 %g 'inf' / '-inf' / 'nan') are legal IEEE 1364
+real_number texts. Before the fix the parser rejected them, silently dropping
+the whole value_change record: dump lost the event, info's time range
+excluded the timestamp, summary under-counted — with no diagnostic. They are
+now kept in the stream verbatim. Equality targets still reject them
+(_parse_target_value), so no condition can match one — a stated limitation,
+not data loss.
+"""
+import contextlib
+import io
+
+import vcd_analyzer as va
+from conftest import load_json_stdout, minimal_vcd, ns, write_vcd
+
+
+DECLS = ('$var real 64 % dac $end\n'
+         '$var wire 1 ! clk $end\n')
+DATA = ('#0\nr100 %\n1!\n'
+        '#10\nrinf %\nrnan %\n'
+        '#20\nr-inf %\n'
+        '#30\nr3.5 %\n')
+
+
+def _dump_json(tmp_path):
+    p = write_vcd(tmp_path, minimal_vcd(DECLS, DATA))
+    v = va.VCDParser(str(p))
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        va.cmd_dump(v, ns(json=True, begin='0ns', end='40ns'))
+    return load_json_stdout(buf.getvalue())
+
+
+def test_dump_keeps_nonfinite_real_records(tmp_path):
+    events = _dump_json(tmp_path)['events']
+    dac = [(e['time_ticks'], e['value']) for e in events if e['path'] == 'tb.dac']
+    assert dac == [(0, '100'), (10, 'inf'), (10, 'nan'), (20, '-inf'), (30, '3.5')]
+
+
+def test_info_time_range_includes_nonfinite_only_tail(tmp_path):
+    # The final timestamp carries ONLY a non-finite real: before the fix it
+    # was invisible to both iter_events and scan_time_range, so t_max
+    # collapsed toward the last finite record.
+    p = write_vcd(tmp_path, minimal_vcd(DECLS, '#0\nr100 %\n#10\nrinf %\n'))
+    v = va.VCDParser(str(p))
+    assert v.scan_time_range() == (0, 10)
+
+
+def test_summary_counts_nonfinite_changes(tmp_path):
+    p = write_vcd(tmp_path, minimal_vcd(DECLS, DATA))
+    v = va.VCDParser(str(p))
+    rows, _undef, counts = va._summary_rows(v, 0, None, None)
+    row = next(r for r in rows if r['path'] == 'tb.dac')
+    assert counts['active'] == 1
+    assert row['changes'] == 4
+    assert row['unique'] == 5
+    # Below the default cap the marker key is absent.
+    assert 'unique_is_exact' not in row
+
+
+def test_nonfinite_values_match_no_condition(tmp_path):
+    # No equality target can name inf/nan, and a finite target simply never
+    # compares equal to them: dac=5 finds only the 100 / 3.5 regions.
+    p = write_vcd(tmp_path, minimal_vcd(DECLS, DATA))
+    v = va.VCDParser(str(p))
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        va.cmd_search(v, ns(json=True, condition=['dac=5'],
+                            begin='0ns', end='40ns'))
+    res = load_json_stdout(buf.getvalue())
+    assert res['mode'] == 'interval'
+    assert res['intervals'] == []

--- a/verify/test_summary_begin_boundary.py
+++ b/verify/test_summary_begin_boundary.py
@@ -1,5 +1,5 @@
 import vcd_analyzer as va
-from conftest import write_vcd, minimal_vcd
+from conftest import ns, write_vcd, minimal_vcd
 
 
 def _row_by_path(rows, path):
@@ -125,3 +125,34 @@ def test_summary_begin_zero_init_only_signal_is_static(tmp_path):
     assert counts["active"] == 1
     assert counts["static"] == 1
 
+
+_CNT_DECL = "$var wire 8 ! cnt $end\n"
+_CNT_DATA = "#0\nb0 !\n#10\nb1 !\n#20\nb10 !\n#30\nb11 !\n"
+
+
+def test_summary_unique_count_is_exact_below_cap(tmp_path):
+    p = write_vcd(tmp_path, minimal_vcd(_CNT_DECL, _CNT_DATA))
+    v = va.VCDParser(str(p))
+    rows, _undef, _counts = va._summary_rows(v, 0, None, None)
+    row = _row_by_path(rows, "tb.cnt")
+    assert row["unique"] == 4
+    # Below the cap the marker key is absent: no existing key changed shape.
+    assert "unique_is_exact" not in row
+
+
+def test_summary_unique_count_caps_and_marks_lower_bound(tmp_path, monkeypatch):
+    monkeypatch.setenv("VCD_ANALYZER_MAX_UNIQUE_VALUES", "2")
+    p = write_vcd(tmp_path, minimal_vcd(_CNT_DECL, _CNT_DATA))
+    v = va.VCDParser(str(p))
+    rows, _undef, _counts = va._summary_rows(v, 0, None, None)
+    row = _row_by_path(rows, "tb.cnt")
+    assert row["unique"] == 2
+    assert row["unique_is_exact"] is False
+
+
+def test_summary_text_marks_capped_unique_as_lower_bound(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VCD_ANALYZER_MAX_UNIQUE_VALUES", "2")
+    p = write_vcd(tmp_path, minimal_vcd(_CNT_DECL, _CNT_DATA))
+    v = va.VCDParser(str(p))
+    va.cmd_summary(v, ns(begin="0ns", end=None, verbose=True))
+    assert "uniq=2+" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Seven fixes from a deep code review of v1.5.0. No existing JSON key changed name, type, or meaning; all non-`search` commands are byte-identical to `main` on the sample fixtures (verified text+JSON across 6 commands).

### Fixed

- **Non-finite real values no longer silently dropped.** C99 7.19.6.1 renders `±inf` as `inf` and NaN as `nan` *optionally followed by implementation-defined characters* (the MSVC CRT emits e.g. `nan(snan)` / `nan(ind)`), and IEEE 1364's `real_number` is `%g` output — but the parser's real regex rejected all of it, so the whole value_change record vanished from `dump`, `info`'s time range, and `summary` counts with no diagnostic. A companion pattern (`_REAL_NONFINITE_RE`) now keeps such records verbatim in the stream, including the bounded `nan(payload)` form.
  - No equality target can name non-finite values: `_parse_target_value` rejects them (nan never compares equal, inf has no finite equal), so `=` never matches one. `!=` with a finite target *does* match non-finite values (`float('nan') == 5` is False) — the same rule as any other non-matching real, now locked by test.
- **`summary`'s distinct-value (`unique`) set grew without bound** (a 32-bit counter over tens of millions of changes kept every value string alive). The set now caps at `VCD_ANALYZER_MAX_UNIQUE_VALUES` (default 65536, read per call like `VCD_ANALYZER_TOKEN_CHUNK_SIZE`). Beyond the cap the count is a lower bound and the row says so: JSON `unique_is_exact: false` (key appears only when capped), text `uniq=N+`.
  - Once a signal's set hits the cap it is frozen, so the per-value membership hash is skipped entirely on all later transitions — the cap now also removes the distinct-counting cost from the hot path, not just the memory.

### CLI robustness

- Ctrl-C exits 130 cleanly instead of printing a traceback.
- stdout/stderr force-reconfigured to UTF-8 (`errors='replace'`) so a legacy Windows codepage cannot turn a valid dump into `UnicodeEncodeError`.

### Internal (dead code)

- Removed `fmt_time`'s unreachable trailing return.
- Dropped `_limit`'s unused `cmd` parameter (7 call sites).
- Merged `cmd_dump` text branch's duplicate `last_t`/`cur` sentinels into one memoized sentinel (JSON branch untouched — it needs the formatted time per event).

## Test plan

- [x] Full suite: **171 passed** (162 existing + 9 new)
- [x] New `verify/test_real_nonfinite.py`: dump keeps inf/nan/`nan(ind)`/`NAN(IND)` records; info time range includes a non-finite-only tail timestamp; summary counts them; malformed payloads (`nan()`, `nan(a b)`) still rejected; `dac=5` (equality) matches nothing; `dac!=5` matches all non-finite records
- [x] Unique-cap tests: exact below cap (marker key absent), capped (lower bound + `unique_is_exact: false`), text `uniq=2+` (cap read per call, so `monkeypatch.setenv` works)
- [x] Live SIGINT probe (`--limit 0` on a 150 MB dump): exit 130, stderr clean, no traceback
- [x] Byte-identical output vs `main` on sample fixtures across info/list/dump/summary/snapshot/compare, text+JSON
- [x] Boundary probe: distinct == cap is exact (no marker); cap+1 sets the marker; `_env_int` guards cap <= 0 / garbage back to default
- [x] nan no-op suppression verified string-based (`prev == val` in `_iter_changes`) — no `nan != nan` always-true hole
- [x] Crash-safety audit: the only `float()` on stored record values (`_value_matches`) is ValueError-guarded, so `nan(payload)` records can never raise in search; `fmt_val` passes real text verbatim

Docs: `CHANGELOG.md` gains a `[1.5.1]` section; `skill/SKILL.md` notes reals may be non-finite (incl. `nan(payload)`); README/README_zh version tables updated.
